### PR TITLE
Switch cryptgeon to official Valkey helm chart

### DIFF
--- a/.github/kubeconform.sh
+++ b/.github/kubeconform.sh
@@ -38,6 +38,9 @@ chmod +x .bin/semver2
 # Initialize apis array
 apis=(--api-versions batch/v1/CronJob)
 
+# Add helm repos from ct.yaml
+helm repo add valkey https://valkey.io/valkey-helm/ || true
+
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
   (cd "charts/${CHART_DIR}"; helm dependency build)

--- a/charts/cryptgeon/Chart.lock
+++ b/charts/cryptgeon/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: valkey
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.0.9
-digest: sha256:44f41bda6ec012c8e511076668d00e09a3e8413c1ce372c9029566ab17425d23
-generated: "2025-05-26T07:30:00.786169+02:00"
+  repository: https://valkey.io/valkey-helm/
+  version: 0.9.3
+digest: sha256:7379cfb883db0b651cfdda1338ff7d2b20985c58152603784832478ed2449486
+generated: "2026-01-25T22:20:53.180998+01:00"

--- a/charts/cryptgeon/Chart.yaml
+++ b/charts/cryptgeon/Chart.yaml
@@ -5,11 +5,11 @@ maintainers:
   - name: swibrow
     email: sam.wibrow@gmail.com
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "2.9.1"
 
 dependencies:
   - name: valkey
-    version: 3.0.9
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 0.9.3
+    repository: https://valkey.io/valkey-helm/
     condition: valkey.enabled

--- a/charts/cryptgeon/README.md
+++ b/charts/cryptgeon/README.md
@@ -1,6 +1,6 @@
 # cryptgeon
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -14,7 +14,7 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | valkey | 3.0.9 |
+| https://valkey.io/valkey-helm/ | valkey | 0.9.3 |
 
 ## Values
 
@@ -25,8 +25,7 @@ A Helm chart for Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| env[0].name | string | `"CRYPTGEON_VALKEY_HOST"` |  |
-| env[0].value | string | `"valkey.default.svc.cluster.local"` |  |
+| env | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cupcakearmy/cryptgeon"` |  |

--- a/charts/cryptgeon/templates/deployment.yaml
+++ b/charts/cryptgeon/templates/deployment.yaml
@@ -36,10 +36,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.env }}
           env:
-            {{- toYaml .Values.env | nindent 12 }}
-          {{- end }}
+            {{- if .Values.valkey.enabled }}
+            - name: CRYPTGEON_VALKEY_HOST
+              value: "{{ include "cryptgeon.fullname" . }}-valkey"
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/cryptgeon/values.yaml
+++ b/charts/cryptgeon/values.yaml
@@ -15,9 +15,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-env:
-  - name: CRYPTGEON_VALKEY_HOST
-    value: "valkey.default.svc.cluster.local"
+env: []
   # - name: EXAMPLE_ENV_VAR
   #   value: "example-value"
   # - name: ANOTHER_ENV_VAR
@@ -25,6 +23,7 @@ env:
   #     secretKeyRef:
   #       name: example-secret
   #       key: example-key
+  # Note: CRYPTGEON_VALKEY_HOST is automatically set when valkey.enabled=true
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,6 @@
+chart-repos:
+  - valkey=https://valkey.io/valkey-helm/
+
 chart-dirs:
   - charts
 


### PR DESCRIPTION
## Summary
- Switch Valkey dependency from Bitnami chart to official Valkey helm chart (v0.9.3)
- Auto-inject `CRYPTGEON_VALKEY_HOST` environment variable when `valkey.enabled=true`
- Remove hardcoded valkey host from values.yaml defaults for cleaner configuration

## Test plan
- [ ] Deploy with `valkey.enabled: true` and verify cryptgeon connects to the subchart
- [ ] Deploy with `valkey.enabled: false` and custom `CRYPTGEON_VALKEY_HOST` in env array